### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM php:7.4-apache
-COPY --chown=www-data:www-data api/ /var/www/html/api/
-COPY --chown=www-data:www-data website/ /var/www/html/website/
-EXPOSE 8080
+
+# copy the server configuration file
+COPY apache/000-default.conf /etc/apache2/sites-available/000-default.conf
+# copy the startup script
+COPY apache/start-apache /usr/local/bin
+# copy the app folders
+COPY api/ /var/www/html/api/
+COPY website/ /var/www/html/website/
+
+EXPOSE 80
+CMD ["start-apache"]

--- a/apache/000-default.conf
+++ b/apache/000-default.conf
@@ -1,0 +1,18 @@
+# 000-default.conf
+
+<VirtualHost *:80>
+    DocumentRoot /var/www/html/website/
+    
+    <Directory "/var/www/html/website/">
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+    
+    Alias /api/ "/var/www/html/api/"
+    <Directory "/var/www/html/api/">
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/apache/start-apache
+++ b/apache/start-apache
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# set the port apache listen to from the $PORT env variable
+sed -i "s/Listen 80/Listen ${PORT:-80}/g" /etc/apache2/ports.conf
+sed -i "s/:80/:${PORT:-80}/g" /etc/apache2/sites-enabled/*
+# set the correct folder permissions
+chown -R www-data:www-data /var/www/html/
+# start the server
+apache2-foreground

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+
+services:
+  cryptofolio:
+  # use this to build Cryptofolio from the Dockerfile or image to pull from the Dockerhub registry
+    build: .
+    # image: xtrendence/cryptofolio:V.2.1.0
+    container_name: cryptofolio
+    restart: unless-stopped
+    ports:
+      - 8080:80
+    # environment:
+    #  PORT: 80
+    volumes:
+      - ./data:/var/www/html/api/data


### PR DESCRIPTION
- added a working apache configuration to the image
- added a startup script that takes care of permissions
- added a docker-compose file for easier management

What is missing

- tags on dockerhub should be numbers only, right now you have V2 instead of 2. I think this breaks tha `latest` tag and the major/minor tag automatic generation
edit: tag can be anything, but you are missing the latest and major/minor tags